### PR TITLE
delete additional About heading

### DIFF
--- a/about.md
+++ b/about.md
@@ -1,4 +1,8 @@
-# About Me
+---
+layout: page
+title: About
+permalink: /about/
+---
 
 Hello! I'm Jonathan Wang, a CS student at NYU Courant who's interested in mobile and web development. Aside from being a full-time student, I'm also a musician and love composing piano music for films, shows and original shorts.
 


### PR DESCRIPTION
closes issue #1 

Your About Me page was missing some layout information and had markdown for the title. I deleted the markdown title and added the layout back in.